### PR TITLE
SQS Extension Supporting FIFO & Standard Queues.

### DIFF
--- a/extensions/sqs/0.1.0.yml
+++ b/extensions/sqs/0.1.0.yml
@@ -1,0 +1,106 @@
+
+id: sqs
+type: binding
+title: SQS Extension supporting FIFO & Standard Queques
+description: Defines the configuration parameters required for AWS SQS for both standard and FIFO ordered queues
+version: '0.1.0'
+author: Paul Taylor
+definitions:
+
+  - hooks:
+      - 'channels.*.publish'
+      - 'channels.*.subscribe'
+    schema:
+      type: object
+      required:
+        - version
+        - queueType
+        - name
+      if:
+        queueType: fifo
+          - messageGroupId
+          - messageDeduplicationId
+      properties:
+        version:
+          type: string
+          const: '0.1.0'
+        queueType:
+          type: string
+          emum: 
+            - fifo
+            - standard
+        name:
+          type: string
+          pattern: '^[a-zA-Z0-9\\.\\-_]+$'
+        if:
+          queueType: fifo
+          messageGroupId:
+            type: string
+            pattern: '^[a-zA-Z0-9\\.\\-_]+$'
+          messageDeduplicationId:
+            type: string
+            pattern: '^[a-zA-Z0-9\\.\\-_]+$'
+        receiveRequestAttemptId:
+          type: string
+          pattern: '^[a-zA-Z0-9\\.\\-_]+$'
+        action:
+          type: string
+          pattern: '^[a-zA-Z0-9\\.\\-_]+$'
+        maxNumberOfMessages:
+          type: integer
+        visibilityTimeout:
+          type: integer
+        waitTimeSeconds:
+          type: integer
+        attributeNames:
+          type: array
+          items:
+            type: string
+              - All
+              - ApproximateFirstReceiveTimestamp
+              - ApproximateReceiveCount
+              - AWSTraceHeader
+              - SenderId
+              - SentTimestamp
+              - MessageDeduplicationId
+              - MessageGroupId
+              - SequenceNumber
+        messageAttributeName:
+          type: array
+          items:
+            type: string
+      examples:
+        - description: Example configuration for both fifo & standard queues
+          exampleFIFOPublish:
+            sqs:
+              publish:
+                version: '0.1.0'
+                queueType: fifo
+                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
+                messageGroupId: 10020
+                messageDeduplicationId: 102
+                action: SendMessage
+          exampleFIFOSubscribe:
+            sqs:
+              subscribe:
+                version: '0.1.0'
+                queueType: fifo
+                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
+                attributeNames: 'MessageGroupId'
+                maxNumberOfMessages: 10
+                visibilityTimeout: 20
+                waitTimeSeconds: 2
+                receiveRequestAttemptId: 'attempt123'
+                messageAttributeName:
+                  - 'myCustomAttribute1'
+                  - 'myCustomAttribute2'
+                action: 'ReceiveMessage'
+          exampleStandardSubscribe:
+            sqs:
+              subscribe:
+                version: '0.1.0'
+                queueType: standard
+                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test'
+                action: 'ReceiveMessage'
+
+

--- a/extensions/sqs/0.1.0.yml
+++ b/extensions/sqs/0.1.0.yml
@@ -1,6 +1,6 @@
 
 id: sqs
-type: binding
+type: bindings
 title: SQS Extension supporting FIFO & Standard Queques
 description: Defines the configuration parameters required for AWS SQS for both standard and FIFO ordered queues
 version: '0.1.0'
@@ -72,35 +72,39 @@ definitions:
       examples:
         - description: Example configuration for both fifo & standard queues
           exampleFIFOPublish:
-            sqs:
-              publish:
-                version: '0.1.0'
-                queueType: fifo
-                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
-                messageGroupId: 10020
-                messageDeduplicationId: 102
-                action: SendMessage
+            publish:
+              bindings:
+                sqs:
+                  version: '0.1.0'
+                  queueType: fifo
+                  name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
+                  messageGroupId: 10020
+                  messageDeduplicationId: 102
+                  action: SendMessage
           exampleFIFOSubscribe:
-            sqs:
-              subscribe:
-                version: '0.1.0'
-                queueType: fifo
-                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
-                attributeNames: 'MessageGroupId'
-                maxNumberOfMessages: 10
-                visibilityTimeout: 20
-                waitTimeSeconds: 2
-                receiveRequestAttemptId: 'attempt123'
-                messageAttributeName:
-                  - 'myCustomAttribute1'
-                  - 'myCustomAttribute2'
-                action: 'ReceiveMessage'
+            subscribe:
+              bindings:
+                sqs:
+                  version: '0.1.0'
+                  queueType: fifo
+                  name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test.fifo'
+                  attributeNames: 'MessageGroupId'
+                  maxNumberOfMessages: 10
+                  visibilityTimeout: 20
+                  waitTimeSeconds: 2
+                  receiveRequestAttemptId: 'attempt123'
+                  messageAttributeName:
+                    - 'myCustomAttribute1'
+                    - 'myCustomAttribute2'
+                  action: 'ReceiveMessage'
           exampleStandardSubscribe:
-            sqs:
-              subscribe:
-                version: '0.1.0'
-                queueType: standard
-                name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test'
-                action: 'ReceiveMessage'
+            subscribe:
+              bindings:
+                sqs:
+                  subscribe:
+                    version: '0.1.0'
+                    queueType: standard
+                    name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test'
+                    action: 'ReceiveMessage'
 
 

--- a/extensions/sqs/0.1.0.yml
+++ b/extensions/sqs/0.1.0.yml
@@ -1,6 +1,6 @@
 
 id: sqs
-type: bindings
+type: generic
 title: SQS Extension supporting FIFO & Standard Queques
 description: Defines the configuration parameters required for AWS SQS for both standard and FIFO ordered queues
 version: '0.1.0'
@@ -106,5 +106,4 @@ definitions:
                     queueType: standard
                     name: 'https://sqs.ap-soautheast-2.amazonaws.com/75555555/msqs-test'
                     action: 'ReceiveMessage'
-
 

--- a/extensions/sqs/0.1.0.yml
+++ b/extensions/sqs/0.1.0.yml
@@ -5,6 +5,14 @@ title: SQS Extension supporting FIFO & Standard Queques
 description: Defines the configuration parameters required for AWS SQS for both standard and FIFO ordered queues
 version: '0.1.0'
 author: Paul Taylor
+contact:
+  email: p.taylor@mulesoft.com
+  url: https://github.com/Paul-T-AU
+  name: Paul Taylor
+tags:
+  - queues
+  - ordering
+  - fifo
 definitions:
 
   - hooks:


### PR DESCRIPTION


**AWS SQS Extension**

- Support for FIFO Queues, with Group ID & Dedupe
- Standard Queue definition
- Sub & Pub config example

**Related issue(s)**

See also Issue # 11 Bindings Feature Request