### PR TITLE
fix: fixed the example in x.md file

### DIFF
--- a/extensions/x.md
+++ b/extensions/x.md
@@ -1,8 +1,8 @@
 # Twitter Extension
-This document defines how to use `twitter` extension in AsyncAPI documents.
+This document defines how to use `x` extension in AsyncAPI documents.
 
 ## Overview 
-This extension allows you to provide the Twitter username of the account representing the team/company of the API.
+This extension allows you to provide the Twitter/X username of the account representing the team/company of the API.
 
 ## Version
 Current version is `0.1.0`.
@@ -11,7 +11,7 @@ Current version is `0.1.0`.
 
 ### Type: String
 
-Name of the Twitter username.
+Name of the Twitter/X username.
 
 ## Extension Location 
 

--- a/extensions/x.md
+++ b/extensions/x.md
@@ -1,4 +1,4 @@
-# Twitter Extension
+# Twitter/X Extension
 This document defines how to use `x` extension in AsyncAPI documents.
 
 ## Overview 

--- a/extensions/x.md
+++ b/extensions/x.md
@@ -25,5 +25,5 @@ asyncapi: '3.0.0'
 info
   title: Strretlights Kafka API
   version: '1.0.0'
-  x-twitter: StreetLightData
+  x-x: StreetLightData
 ```

--- a/extensions/x.md
+++ b/extensions/x.md
@@ -16,12 +16,12 @@ Name of the Twitter username.
 ## Extension Location 
 
 This extension can be used in the following locations:
-- [Info Object](https://www.asyncapi.com/docs/reference/specification/v2.6.0#infoObject)
+- [Info Object](https://www.asyncapi.com/docs/reference/specification/v3.0.0#infoObject)
 
 ## Example
 
 ```yaml
-asyncapi: '2.6.0'
+asyncapi: '3.0.0'
 info
   title: Strretlights Kafka API
   version: '1.0.0'


### PR DESCRIPTION
it was written `x-twitter` instead of `x-x`